### PR TITLE
Fix shiny version and remove non-existent shinywidgets from requireme…

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -15,10 +15,10 @@ dependencies:
   - plotly=5.24.1
 
   # Dashboard
-  - shiny=1.2.1
-  - shinywidgets=0.3.5
+  - shiny=1.3.0
+  - shinywidgets=0.3.4
 
-  # Development (local only, not needed for deployment)
+  # Development (local only — not needed for deployment)
   - jupyterlab=4.3.3
   - ipykernel=6.29.5
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-
 # Data Handling
 pandas==2.2.3
 numpy==1.26.4
@@ -7,8 +6,7 @@ numpy==1.26.4
 plotly==5.24.1
 
 # Shiny Dashboard
-shiny==1.2.1
-shinywidgets==0.3.5
+shiny==1.3.0
 
 # Data Download (Kaggle API)
 kaggle==1.6.17


### PR DESCRIPTION
#43 

Fixed shiny version pin and removed shinywidgets==0.3.5 from requirements.txt (version does not exist on PyPI). Updated environment.yml with correct versions to resolve Posit Connect Cloud deployment failure.