### PR TITLE
fix: update environment and requirements for AI chatbot deps

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -6,6 +6,7 @@ channels:
 
 dependencies:
   - python=3.11.9
+  - pip
 
   # Data Handling
   - pandas=2.2.3
@@ -16,15 +17,14 @@ dependencies:
 
   # Dashboard
   - shiny=1.3.0
-  - shinywidgets=0.3.4
 
-  # Development (local only — not needed for deployment)
+  # Development
   - jupyterlab=4.3.3
   - ipykernel=6.29.5
 
   - pip:
       - kaggle==1.6.17
-      - python-dotenv
-      - anthropic
-      - chatlas
-      - querychat
+      - python-dotenv==0.21.0
+      - anthropic==0.84.0
+      - chatlas==0.15.2
+      - querychat==0.5.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ plotly==5.24.1
 # Shiny Dashboard
 shiny==1.3.0
 
-# Data Download (Kaggle API)
+# Data Download
 kaggle==1.6.17
 
 # AI Chatbot

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -8,5 +8,11 @@ plotly==5.24.1
 # Shiny Dashboard
 shiny==1.3.0
 
-# Data Download (Kaggle API)
+# Data Download
 kaggle==1.6.17
+
+# AI Chatbot
+python-dotenv==0.21.0
+anthropic==0.84.0
+chatlas==0.15.2
+querychat==0.5.1


### PR DESCRIPTION
- Remove shinywidgets from conda deps (pip-only package)
- Add python-dotenv, anthropic, chatlas, querychat to environment.yml
- Sync root and src requirements.txt with pinned AI dep versions

Closes: #72 