### PR TITLE
fix: update shiny>=1.5.1 to resolve querychat dependency conflict

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ numpy==1.26.4
 plotly==5.24.1
 
 # Shiny Dashboard
-shiny==1.3.0
+shiny>=1.5.1
 
 # Data Download
 kaggle==1.6.17

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -6,7 +6,7 @@ numpy==1.26.4
 plotly==5.24.1
 
 # Shiny Dashboard
-shiny==1.3.0
+shiny>=1.5.1
 
 # Data Download
 kaggle==1.6.17


### PR DESCRIPTION
Problem:
Posit Cloud deployment was failing with "Unable to resolve dependency" because `querychat==0.5.1` requires `shiny>=1.5.1` but both `requirements.txt` files had `shiny==1.3.0` pinned, creating an unsatisfiable conflict.

Fix:
Updated `shiny==1.3.0` → `shiny>=1.5.1` in both:
- `requirements.txt` (root)
- `src/requirements.txt`

Tested locally and app runs successfully.

#71 